### PR TITLE
Nixpkgs 21.11 shakedown

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -173,7 +173,7 @@ in
   moore = callPackage ./pkgs/moore {};
 
   notmuch = (super.notmuch.overrideAttrs (oa: {
-    patches = (oa.patches or []) ++ [ ./patches/0001-Display-application-pkcs7-mime-parts-smime-decryptio.patch ];
+    #patches = (oa.patches or []) ++ [ ./patches/0001-Display-application-pkcs7-mime-parts-smime-decryptio.patch ];
   })).override{ gmime = self.gmime_patched; };
 
   open-zwave = callPackage ./pkgs/open-zwave {};

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1644429551,
+        "narHash": "sha256-2AezGc7tHkCIT/goP1wQACMDHqD96dhaUPgl42Sd++E=",
+        "path": "/nix/store/pidfq7wc9cb2qc1srif18n17wkfw62gp-source",
+        "rev": "36043abed10691492e40e7d9d9f1f8def7cb12ba",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,14 @@
+{
+  outputs = { self, nixpkgs, ... }: let
+    forAllSystems = f: nixpkgs.lib.genAttrs [ "x86_64-linux" ] (system: f {
+      inherit system;
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ self.overlay ];
+      };
+    });
+  in {
+    overlay = final: prev: (import ./default.nix) final prev;
+    legacyPackages = forAllSystems ({ pkgs, ... }: pkgs);
+  };
+}

--- a/modules/opensnitch.nix
+++ b/modules/opensnitch.nix
@@ -43,7 +43,6 @@ in
 
   options = {
     services.opensnitch = with lib; {
-      enable = mkEnableOption "opensnitch";
 
       uiConfig = mkOption {
         type = types.attrs;

--- a/pkgs/spacemacs/patches/0012-Remove-update-checking-and-recompilation-magic.patch
+++ b/pkgs/spacemacs/patches/0012-Remove-update-checking-and-recompilation-magic.patch
@@ -26,15 +26,14 @@ index a569e53a1..307edfe58 100644
    (spacemacs//revision-check))
  
 diff --git a/init.el b/init.el
-index 7f2526cb6..141256730 100644
 --- a/init.el
 +++ b/init.el
 @@ -37,18 +37,6 @@
- (load (concat spacemacs-core-directory "core-dumper.el")
+ (load (concat spacemacs-core-directory "core-dumper")
        nil (not init-file-debug))
  
 -;; Remove compiled core files if they become stale or Emacs version has changed.
--(load (concat spacemacs-core-directory "core-compilation.el")
+-(load (concat spacemacs-core-directory "core-compilation")
 -      nil (not init-file-debug))
 -(load spacemacs--last-emacs-version-file t (not init-file-debug))
 -(when (or (not (string= spacemacs--last-emacs-version emacs-version))
@@ -48,6 +47,3 @@ index 7f2526cb6..141256730 100644
  (if (not (version<= spacemacs-emacs-min-version emacs-version))
      (error (concat "Your version of Emacs (%s) is too old. "
                     "Spacemacs requires Emacs version %s or above.")
--- 
-2.29.3
-

--- a/pkgs/spacemacs/src.nix
+++ b/pkgs/spacemacs/src.nix
@@ -1,6 +1,6 @@
 {
   owner = "syl20bnr";
   repo = "spacemacs";
-  rev = "b992ad29bb0f0859db6df30bfac7492c49a8a22c";
-  sha256 = "12gh5rna6dalgyg1af1zcy26y638nmkns0lswbvv3rl5f5k08gvz";
+  rev = "efdfecbf8f72d3de4a410f9d653f8b91e569063c";
+  sha256 = "sha256-kLwTnGDqNHJxipqmv6qFe8zv+GK3P92vG9HTRhXxdJ0=";
 }


### PR DESCRIPTION
General 21.11 shakedown PR.

`opensnitch.enable` is provided upstream (in a minimal module that should not further collide with this implementation)

`notmuch` pkcs7-mime patch no longer applies, this just fixes the build.

`spacemacs` update